### PR TITLE
refactor: ln invoice atm endpoint

### DIFF
--- a/models.py
+++ b/models.py
@@ -35,7 +35,3 @@ class FossaPayment(BaseModel):
     pin: int
     sats: int
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-
-
-class Lnurlencode(BaseModel):
-    url: str

--- a/views_api_atm.py
+++ b/views_api_atm.py
@@ -86,10 +86,6 @@ async def _validate_payment_request(pr: str, amount_msat: int) -> str:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN, detail="Not valid payment request"
         )
-    if not invoice.payment_hash:
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN, detail="Not valid payment request"
-        )
     if not invoice.amount_msat or int(invoice.amount_msat) != amount_msat:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN,


### PR DESCRIPTION
- fix issue where an invoice from lnurl/lnaddress was not paid
- remove unused lnurlencode endpoint with model
- refactor lnurl/invoice validation into a fn
- there was a duplication of register_atm_payment